### PR TITLE
Disallow dragging cards already on the grid

### DIFF
--- a/site/gridcannon.js
+++ b/site/gridcannon.js
@@ -466,6 +466,10 @@ function dragstart(e) {
 		e.preventDefault();
 		return;
 	}
+	if(c!=this || this.parentNode.classList.contains("slot")) {
+		e.preventDefault();
+		return;
+	}
 	e.dataTransfer.setData('text', '.card[data-value="'+e.target.dataset.value + '"][data-suit="'+e.target.dataset.suit+'"]');
 	window.dragCard = e.target;
 


### PR DESCRIPTION
hello!

This addresses #4. I've added an extra check here because it felt cleaner, but if you'd prefer I can add it to the `shamePile` check.

I've played half a game with this enabled and didn't notice any issues. I can't think of anything in the rules that allows you to move cards already placed.